### PR TITLE
Add terminal capability service and color palette utilities

### DIFF
--- a/Sources/CNCursesSupport/Shims/include/CNCursesSupportShims.h
+++ b/Sources/CNCursesSupport/Shims/include/CNCursesSupportShims.h
@@ -71,6 +71,86 @@ static inline int32_t cncurses_doupdate(void) {
     return (int32_t)doupdate();
 }
 
+static inline bool cncurses_has_colors(void) {
+    return has_colors() ? true : false;
+}
+
+static inline int32_t cncurses_start_color(void) {
+    return (int32_t)start_color();
+}
+
+static inline int32_t cncurses_use_default_colors(void) {
+    return (int32_t)use_default_colors();
+}
+
+static inline int32_t cncurses_init_pair(int16_t pair, int16_t foreground, int16_t background) {
+    return (int32_t)init_pair(pair, foreground, background);
+}
+
+static inline int32_t cncurses_color_pair_count(void) {
+    return (int32_t)COLOR_PAIRS;
+}
+
+static inline int32_t cncurses_color_count(void) {
+    return (int32_t)COLORS;
+}
+
+static inline bool cncurses_can_change_color(void) {
+    return can_change_color() ? true : false;
+}
+
+static inline int16_t cncurses_color_black(void) {
+    return (int16_t)COLOR_BLACK;
+}
+
+static inline int16_t cncurses_color_red(void) {
+    return (int16_t)COLOR_RED;
+}
+
+static inline int16_t cncurses_color_green(void) {
+    return (int16_t)COLOR_GREEN;
+}
+
+static inline int16_t cncurses_color_yellow(void) {
+    return (int16_t)COLOR_YELLOW;
+}
+
+static inline int16_t cncurses_color_blue(void) {
+    return (int16_t)COLOR_BLUE;
+}
+
+static inline int16_t cncurses_color_magenta(void) {
+    return (int16_t)COLOR_MAGENTA;
+}
+
+static inline int16_t cncurses_color_cyan(void) {
+    return (int16_t)COLOR_CYAN;
+}
+
+static inline int16_t cncurses_color_white(void) {
+    return (int16_t)COLOR_WHITE;
+}
+
+static inline bool cncurses_has_mouse(void) {
+    return has_mouse() ? true : false;
+}
+
+static inline unsigned long cncurses_all_mouse_events(void) {
+    return (unsigned long)ALL_MOUSE_EVENTS;
+}
+
+static inline unsigned long cncurses_report_mouse_position(void) {
+    return (unsigned long)REPORT_MOUSE_POSITION;
+}
+
+static inline int32_t cncurses_set_mousemask(unsigned long mask) {
+    mmask_t previous = mousemask((mmask_t)mask, NULL);
+    if (previous == (mmask_t)ERR) {
+        return (int32_t)ERR;
+    }
+    return (int32_t)OK;
+}
+
 static inline void cncurses_getmaxyx(CNCursesWindowRef window, int32_t *rows, int32_t *columns) {
     int y = 0;
     int x = 0;

--- a/Sources/CNCursesSupport/Swift/Capabilities.swift
+++ b/Sources/CNCursesSupport/Swift/Capabilities.swift
@@ -1,0 +1,71 @@
+@_implementationOnly import CNCursesSupportShims
+import Foundation
+
+package enum CNCursesColorAPI {
+    package static var hasColorSupport: Bool {
+        cncurses_has_colors()
+    }
+
+    package static func startColor() throws {
+        try CNCursesCall.check(result: cncurses_start_color(), name: "start_color")
+    }
+
+    package static func enableDefaultColors() -> Bool {
+        cncurses_use_default_colors() != cncurses_error()
+    }
+
+    package static func colorCount() -> Int {
+        Int(cncurses_color_count())
+    }
+
+    package static func colorPairCount() -> Int {
+        Int(cncurses_color_pair_count())
+    }
+
+    package static func canChangeColor() -> Bool {
+        cncurses_can_change_color()
+    }
+
+    package static func initializePair(identifier: Int16, foreground: Int16, background: Int16)
+        throws
+    {
+        try CNCursesCall.check(
+            result: cncurses_init_pair(identifier, foreground, background),
+            name: "init_pair"
+        )
+    }
+
+    package static func blackIdentifier() -> Int16 { cncurses_color_black() }
+
+    package static func redIdentifier() -> Int16 { cncurses_color_red() }
+
+    package static func greenIdentifier() -> Int16 { cncurses_color_green() }
+
+    package static func yellowIdentifier() -> Int16 { cncurses_color_yellow() }
+
+    package static func blueIdentifier() -> Int16 { cncurses_color_blue() }
+
+    package static func magentaIdentifier() -> Int16 { cncurses_color_magenta() }
+
+    package static func cyanIdentifier() -> Int16 { cncurses_color_cyan() }
+
+    package static func whiteIdentifier() -> Int16 { cncurses_color_white() }
+}
+
+package enum CNCursesMouseAPI {
+    package static var hasMouseSupport: Bool {
+        cncurses_has_mouse()
+    }
+
+    package static func setMouseMask(_ mask: UInt) throws {
+        try CNCursesCall.check(result: cncurses_set_mousemask(mask), name: "mousemask")
+    }
+
+    package static func allEventsMask() -> UInt {
+        UInt(cncurses_all_mouse_events())
+    }
+
+    package static func reportPositionMask() -> UInt {
+        UInt(cncurses_report_mouse_position())
+    }
+}

--- a/Sources/SwiftCursesKit/Runtime/AppContext.swift
+++ b/Sources/SwiftCursesKit/Runtime/AppContext.swift
@@ -15,6 +15,21 @@ public struct AppContext: Sendable {
     /// The root screen associated with the running application.
     public var screen: TerminalScreen { screenBox }
 
+    /// The detected terminal capabilities for the active session.
+    public var capabilities: TerminalCapabilities { runtime.capabilitiesSnapshot() }
+
+    /// Provides asynchronous access to the latest capability snapshot.
+    /// - Returns: The most recent capability information detected by the runtime.
+    public func capabilities() async -> TerminalCapabilities {
+        runtime.capabilitiesSnapshot()
+    }
+
+    /// A convenience accessor for the current terminal size.
+    public var terminalSize: TerminalSize? { screenBox.size }
+
+    /// Provides access to the shared color palette for the active session.
+    public var palette: ColorPalette { runtime.palette }
+
     /// Requests termination of the active runtime loop.
     public func requestShutdown() {
         runtime.requestShutdown()
@@ -23,5 +38,23 @@ public struct AppContext: Sendable {
     /// Asynchronously requests termination of the active runtime loop.
     public func quit() async {
         requestShutdown()
+    }
+
+    /// Configures the mouse capture mask for the session.
+    /// - Parameter options: The mask that should be applied. Pass an empty option set to disable capture.
+    /// - Throws: ``MouseCaptureError`` when the runtime cannot honor the request.
+    public func setMouseCapture(_ options: MouseCaptureOptions) throws {
+        try runtime.setMouseCapture(options: options)
+    }
+
+    /// Enables mouse capture for the supplied set of events.
+    /// - Parameter options: The mouse events to subscribe to. Defaults to ``MouseCaptureOptions.buttonEvents``.
+    public func enableMouseCapture(options: MouseCaptureOptions = .buttonEvents) throws {
+        try setMouseCapture(options)
+    }
+
+    /// Disables mouse capture for the active session.
+    public func disableMouseCapture() throws {
+        try setMouseCapture([])
     }
 }

--- a/Sources/SwiftCursesKit/Runtime/Color/ColorPair.swift
+++ b/Sources/SwiftCursesKit/Runtime/Color/ColorPair.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Represents a configured ncurses color pair identifier.
+public struct ColorPair: Sendable, Hashable {
+    /// The raw ncurses color pair identifier.
+    public let rawValue: Int16
+
+    /// Creates a new color pair wrapper.
+    /// - Parameter rawValue: The ncurses color pair identifier.
+    public init(rawValue: Int16) {
+        self.rawValue = rawValue
+    }
+
+    /// The default color pair configured by ncurses.
+    public static var `default`: ColorPair { ColorPair(rawValue: 0) }
+}

--- a/Sources/SwiftCursesKit/Runtime/Color/ColorPairConfiguration.swift
+++ b/Sources/SwiftCursesKit/Runtime/Color/ColorPairConfiguration.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Describes the foreground and background colors that should be assigned to a color pair.
+public struct ColorPairConfiguration: Sendable, Hashable {
+    /// The desired foreground color, or `nil` to use the terminal default.
+    public var foreground: TerminalColor?
+    /// The desired background color, or `nil` to use the terminal default.
+    public var background: TerminalColor?
+
+    /// Creates a configuration with the provided colors.
+    /// - Parameters:
+    ///   - foreground: The foreground color, or `nil` for the default.
+    ///   - background: The background color, or `nil` for the default.
+    public init(foreground: TerminalColor? = nil, background: TerminalColor? = nil) {
+        self.foreground = foreground
+        self.background = background
+    }
+
+    /// A configuration that preserves the terminal defaults.
+    public static var monochrome: ColorPairConfiguration { ColorPairConfiguration() }
+
+    var isDefault: Bool { foreground == nil && background == nil }
+
+    var requiresDefaultColors: Bool { foreground == nil || background == nil }
+
+    func isSupported(by capabilities: TerminalCapabilities) -> Bool {
+        guard capabilities.supportsColor else {
+            return false
+        }
+        if requiresDefaultColors && !capabilities.supportsDefaultColors {
+            return false
+        }
+        if let foreground, !foreground.isSupported(by: capabilities) {
+            return false
+        }
+        if let background, !background.isSupported(by: capabilities) {
+            return false
+        }
+        return true
+    }
+
+    func resolvedComponents(for capabilities: TerminalCapabilities) -> (Int16, Int16) {
+        let defaultSentinel: Int16 = -1
+        let foregroundValue = foreground?.rawValue ?? defaultSentinel
+        let backgroundValue = background?.rawValue ?? defaultSentinel
+        return (foregroundValue, backgroundValue)
+    }
+}

--- a/Sources/SwiftCursesKit/Runtime/Color/ColorPalette.swift
+++ b/Sources/SwiftCursesKit/Runtime/Color/ColorPalette.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Manages ncurses color pair allocation with automatic capability fallbacks.
+public struct ColorPalette: Sendable {
+    private let runtime: TerminalRuntimeCoordinator
+
+    internal init(runtime: TerminalRuntimeCoordinator) {
+        self.runtime = runtime
+    }
+
+    /// The capabilities that were detected for the active terminal session.
+    public var capabilities: TerminalCapabilities {
+        runtime.capabilitiesSnapshot()
+    }
+
+    /// Resolves the provided configuration to a color pair identifier.
+    /// - Parameter configuration: The desired foreground and background colors.
+    /// - Returns: The configured color pair, or ``ColorPair.default`` when colors are unavailable.
+    public func pair(for configuration: ColorPairConfiguration) throws -> ColorPair {
+        try runtime.colorPair(for: configuration)
+    }
+}

--- a/Sources/SwiftCursesKit/Runtime/Color/ColorPaletteError.swift
+++ b/Sources/SwiftCursesKit/Runtime/Color/ColorPaletteError.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Errors thrown by the color palette when configuring ncurses color pairs.
+public enum ColorPaletteError: Error, Equatable {
+    /// Indicates that the terminal cannot allocate additional color pairs.
+    case capacityExceeded
+    /// Indicates that the terminal rejected the requested color configuration.
+    /// - Parameter code: The ncurses error code that was returned.
+    case ncursesCallFailed(code: Int32)
+}

--- a/Sources/SwiftCursesKit/Runtime/Color/TerminalColor.swift
+++ b/Sources/SwiftCursesKit/Runtime/Color/TerminalColor.swift
@@ -1,0 +1,68 @@
+import CNCursesSupport
+import Foundation
+
+/// Represents a color index supported by the underlying terminal.
+public struct TerminalColor: Sendable, Hashable {
+    /// The raw ncurses color index.
+    public let rawValue: Int16
+
+    /// Creates a color from the specified ncurses color index.
+    /// - Parameter rawValue: The color index to represent.
+    public init(rawValue: Int16) {
+        self.rawValue = rawValue
+    }
+
+    /// Creates a color from an arbitrary integer value.
+    /// - Parameter index: The ncurses color index.
+    public init(index: Int) {
+        self.rawValue = Int16(index)
+    }
+
+    /// The standard ncurses black color.
+    public static var black: TerminalColor {
+        TerminalColor(rawValue: CNCursesColorAPI.blackIdentifier())
+    }
+
+    /// The standard ncurses red color.
+    public static var red: TerminalColor {
+        TerminalColor(rawValue: CNCursesColorAPI.redIdentifier())
+    }
+
+    /// The standard ncurses green color.
+    public static var green: TerminalColor {
+        TerminalColor(rawValue: CNCursesColorAPI.greenIdentifier())
+    }
+
+    /// The standard ncurses yellow color.
+    public static var yellow: TerminalColor {
+        TerminalColor(rawValue: CNCursesColorAPI.yellowIdentifier())
+    }
+
+    /// The standard ncurses blue color.
+    public static var blue: TerminalColor {
+        TerminalColor(rawValue: CNCursesColorAPI.blueIdentifier())
+    }
+
+    /// The standard ncurses magenta color.
+    public static var magenta: TerminalColor {
+        TerminalColor(rawValue: CNCursesColorAPI.magentaIdentifier())
+    }
+
+    /// The standard ncurses cyan color.
+    public static var cyan: TerminalColor {
+        TerminalColor(rawValue: CNCursesColorAPI.cyanIdentifier())
+    }
+
+    /// The standard ncurses white color.
+    public static var white: TerminalColor {
+        TerminalColor(rawValue: CNCursesColorAPI.whiteIdentifier())
+    }
+
+    /// Validates whether the color value is within the specified capability bounds.
+    /// - Parameter capabilities: The terminal capabilities describing color support.
+    /// - Returns: `true` if the color index can be used with the provided capabilities.
+    public func isSupported(by capabilities: TerminalCapabilities) -> Bool {
+        let index = Int(rawValue)
+        return index >= 0 && index < capabilities.colorCount
+    }
+}

--- a/Sources/SwiftCursesKit/Runtime/Color/TerminalTheme.swift
+++ b/Sources/SwiftCursesKit/Runtime/Color/TerminalTheme.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Describes a collection of color roles that can be resolved against a ``ColorPalette``.
+public struct TerminalTheme<Role: Hashable & Sendable>: Sendable {
+    /// Represents a single themed color definition.
+    public struct Entry: Sendable, Hashable {
+        /// The preferred color configuration when the terminal supports colors.
+        public var configuration: ColorPairConfiguration
+        /// The fallback configuration used when colors are unavailable.
+        public var fallback: ColorPairConfiguration
+
+        /// Creates a themed entry.
+        /// - Parameters:
+        ///   - configuration: The preferred color pair configuration.
+        ///   - fallback: The configuration applied when colors are unavailable. Defaults to ``ColorPairConfiguration.monochrome``.
+        public init(
+            configuration: ColorPairConfiguration,
+            fallback: ColorPairConfiguration = .monochrome
+        ) {
+            self.configuration = configuration
+            self.fallback = fallback
+        }
+    }
+
+    private let entries: [Role: Entry]
+
+    /// Creates a theme with the supplied entries.
+    /// - Parameter entries: A dictionary mapping role identifiers to theme entries.
+    public init(entries: [Role: Entry]) {
+        self.entries = entries
+    }
+
+    /// Resolves the color pair for the provided role using the supplied palette.
+    /// - Parameters:
+    ///   - role: The logical role to resolve.
+    ///   - palette: The palette that manages ncurses color pairs.
+    /// - Returns: The resolved color pair.
+    public func colorPair(for role: Role, using palette: ColorPalette) throws -> ColorPair {
+        let capabilities = palette.capabilities
+        guard capabilities.supportsColor else {
+            let entry = entries[role]
+            return try palette.pair(for: entry?.fallback ?? .monochrome)
+        }
+        guard let entry = entries[role] else {
+            return try palette.pair(for: .monochrome)
+        }
+        if entry.configuration.isSupported(by: capabilities) {
+            return try palette.pair(for: entry.configuration)
+        }
+        return try palette.pair(for: entry.fallback)
+    }
+}

--- a/Sources/SwiftCursesKit/Runtime/Internal/ColorPairRegistry.swift
+++ b/Sources/SwiftCursesKit/Runtime/Internal/ColorPairRegistry.swift
@@ -1,0 +1,82 @@
+import CNCursesSupport
+import Foundation
+
+/// Manages allocation of ncurses color pairs and caches previously configured combinations.
+final class ColorPairRegistry: @unchecked Sendable {
+    private enum Evaluation {
+        case defaultPair
+        case cached(ColorPair)
+        case allocate(identifier: Int16, capabilities: TerminalCapabilities)
+        case capacityExceeded
+    }
+
+    private let lock = NSLock()
+    private var capabilities = TerminalCapabilities.headless
+    private var cache: [ColorPairConfiguration: ColorPair] = [:]
+    private var nextIdentifier: Int16 = 1
+
+    func updateCapabilities(_ capabilities: TerminalCapabilities) {
+        lock.withLock {
+            self.capabilities = capabilities
+            cache.removeAll(keepingCapacity: false)
+            nextIdentifier = 1
+        }
+    }
+
+    func reset() {
+        lock.withLock {
+            capabilities = .headless
+            cache.removeAll(keepingCapacity: false)
+            nextIdentifier = 1
+        }
+    }
+
+    func pair(for configuration: ColorPairConfiguration) throws -> ColorPair {
+        let evaluation = lock.withLock { () -> Evaluation in
+            let capabilities = self.capabilities
+            if configuration.isDefault || !capabilities.supportsColor {
+                return .defaultPair
+            }
+            guard configuration.isSupported(by: capabilities) else {
+                return .defaultPair
+            }
+            if let cached = cache[configuration] {
+                return .cached(cached)
+            }
+            guard nextIdentifier < Int16(capabilities.colorPairCount) else {
+                return .capacityExceeded
+            }
+            let identifier = nextIdentifier
+            nextIdentifier += 1
+            let pair = ColorPair(rawValue: identifier)
+            cache[configuration] = pair
+            return .allocate(identifier: identifier, capabilities: capabilities)
+        }
+
+        switch evaluation {
+        case .defaultPair:
+            return .default
+        case let .cached(pair):
+            return pair
+        case let .allocate(identifier, capabilities):
+            let components = configuration.resolvedComponents(for: capabilities)
+            do {
+                try CNCursesColorAPI.initializePair(
+                    identifier: identifier,
+                    foreground: components.0,
+                    background: components.1
+                )
+            } catch let error as CNCursesRuntimeError {
+                if case let .callFailed(name: _, code: code) = error {
+                    throw ColorPaletteError.ncursesCallFailed(code: code)
+                }
+                throw ColorPaletteError.ncursesCallFailed(code: -1)
+            } catch {
+                throw ColorPaletteError.ncursesCallFailed(code: -1)
+            }
+            return ColorPair(rawValue: identifier)
+        case .capacityExceeded:
+            throw ColorPaletteError.capacityExceeded
+        }
+    }
+}

--- a/Sources/SwiftCursesKit/Runtime/MouseCaptureOptions.swift
+++ b/Sources/SwiftCursesKit/Runtime/MouseCaptureOptions.swift
@@ -1,0 +1,33 @@
+import CNCursesSupport
+import Foundation
+
+/// Represents the set of mouse events that should be captured by ncurses.
+public struct MouseCaptureOptions: OptionSet, Sendable {
+    public let rawValue: UInt
+
+    /// Creates a new option set.
+    /// - Parameter rawValue: The underlying ncurses mask value.
+    public init(rawValue: UInt) {
+        self.rawValue = rawValue
+    }
+
+    /// Captures all mouse button events supported by ncurses.
+    public static let buttonEvents = MouseCaptureOptions(rawValue: CNCursesMouseAPI.allEventsMask())
+
+    /// Enables reporting of mouse motion while buttons are pressed.
+    public static let motion = MouseCaptureOptions(rawValue: CNCursesMouseAPI.reportPositionMask())
+
+    /// Captures all available mouse events.
+    public static let all: MouseCaptureOptions = [.buttonEvents, .motion]
+}
+
+/// Errors produced while configuring mouse capture.
+public enum MouseCaptureError: Error, Equatable {
+    /// Indicates that mouse capture was requested while the runtime is not active.
+    case runtimeInactive
+    /// Indicates that the terminal does not support mouse events.
+    case unsupported
+    /// Indicates that ncurses returned an error code.
+    /// - Parameter code: The ncurses error code returned from `mousemask`.
+    case ncursesCallFailed(code: Int32)
+}

--- a/Sources/SwiftCursesKit/Runtime/RuntimeScreen.swift
+++ b/Sources/SwiftCursesKit/Runtime/RuntimeScreen.swift
@@ -10,4 +10,7 @@ public struct TerminalScreen: Sendable {
 
     /// The ncurses standard screen window.
     public var rootWindow: Window { rootWindowReference }
+
+    /// The terminal size reported for the root window, if available.
+    public var size: TerminalSize? { rootWindowReference.size }
 }

--- a/Sources/SwiftCursesKit/Runtime/TerminalCapabilities.swift
+++ b/Sources/SwiftCursesKit/Runtime/TerminalCapabilities.swift
@@ -1,0 +1,103 @@
+import CNCursesSupport
+import Foundation
+
+/// Represents the runtime capabilities detected for the attached terminal.
+public struct TerminalCapabilities: Sendable, Equatable {
+    /// Indicates whether the runtime is operating without a terminal.
+    public var isHeadless: Bool
+    /// Indicates whether color rendering is available.
+    public var supportsColor: Bool
+    /// The number of distinct colors reported by the terminal.
+    public var colorCount: Int
+    /// The number of color pairs supported by the terminal runtime.
+    public var colorPairCount: Int
+    /// Indicates whether the terminal honors the `-1` default color sentinel.
+    public var supportsDefaultColors: Bool
+    /// Indicates whether the terminal allows runtime color reconfiguration.
+    public var supportsDynamicColorChanges: Bool
+    /// Indicates whether mouse input is available.
+    public var supportsMouse: Bool
+
+    /// Creates a custom capabilities description.
+    /// - Parameters:
+    ///   - isHeadless: Indicates whether the runtime is headless.
+    ///   - supportsColor: Indicates whether color rendering is available.
+    ///   - colorCount: The maximum number of colors supported.
+    ///   - colorPairCount: The maximum number of color pairs supported.
+    ///   - supportsDefaultColors: Indicates whether the terminal supports default colors.
+    ///   - supportsDynamicColorChanges: Indicates dynamic color support.
+    ///   - supportsMouse: Indicates whether mouse input is supported.
+    public init(
+        isHeadless: Bool,
+        supportsColor: Bool,
+        colorCount: Int,
+        colorPairCount: Int,
+        supportsDefaultColors: Bool,
+        supportsDynamicColorChanges: Bool,
+        supportsMouse: Bool
+    ) {
+        self.isHeadless = isHeadless
+        self.supportsColor = supportsColor
+        self.colorCount = colorCount
+        self.colorPairCount = colorPairCount
+        self.supportsDefaultColors = supportsDefaultColors
+        self.supportsDynamicColorChanges = supportsDynamicColorChanges
+        self.supportsMouse = supportsMouse
+    }
+
+    /// A capabilities description for headless execution.
+    public static var headless: TerminalCapabilities {
+        TerminalCapabilities(
+            isHeadless: true,
+            supportsColor: false,
+            colorCount: 0,
+            colorPairCount: 0,
+            supportsDefaultColors: false,
+            supportsDynamicColorChanges: false,
+            supportsMouse: false
+        )
+    }
+}
+
+enum TerminalCapabilitiesInspector {
+    static func inspect() -> TerminalCapabilities {
+        guard CNCursesRuntime.isHeadless == false else {
+            return .headless
+        }
+
+        var supportsColor = false
+        var colorCount = 0
+        var colorPairCount = 0
+        var supportsDefaultColors = false
+        var supportsDynamicColorChanges = false
+
+        if CNCursesColorAPI.hasColorSupport {
+            do {
+                try CNCursesColorAPI.startColor()
+                supportsColor = true
+                colorCount = max(CNCursesColorAPI.colorCount(), 0)
+                colorPairCount = max(CNCursesColorAPI.colorPairCount(), 0)
+                supportsDefaultColors = CNCursesColorAPI.enableDefaultColors()
+                supportsDynamicColorChanges = CNCursesColorAPI.canChangeColor()
+            } catch {
+                supportsColor = false
+                colorCount = 0
+                colorPairCount = 0
+                supportsDefaultColors = false
+                supportsDynamicColorChanges = false
+            }
+        }
+
+        let supportsMouse = CNCursesMouseAPI.hasMouseSupport && !CNCursesRuntime.isHeadless
+
+        return TerminalCapabilities(
+            isHeadless: false,
+            supportsColor: supportsColor,
+            colorCount: colorCount,
+            colorPairCount: colorPairCount,
+            supportsDefaultColors: supportsDefaultColors,
+            supportsDynamicColorChanges: supportsDynamicColorChanges,
+            supportsMouse: supportsMouse
+        )
+    }
+}

--- a/Sources/SwiftCursesKit/Runtime/TerminalSize.swift
+++ b/Sources/SwiftCursesKit/Runtime/TerminalSize.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Represents the current terminal dimensions in rows and columns.
+public struct TerminalSize: Equatable, Sendable {
+    /// The number of character rows available.
+    public var rows: Int
+    /// The number of character columns available.
+    public var columns: Int
+
+    /// Creates a new terminal size descriptor.
+    /// - Parameters:
+    ///   - rows: The number of rows.
+    ///   - columns: The number of columns.
+    public init(rows: Int, columns: Int) {
+        self.rows = rows
+        self.columns = columns
+    }
+}

--- a/Sources/SwiftCursesKit/Runtime/Window.swift
+++ b/Sources/SwiftCursesKit/Runtime/Window.swift
@@ -23,6 +23,14 @@ public final class Window: @unchecked Sendable {
     /// Indicates whether the underlying ncurses window has been closed.
     public var isClosed: Bool { handle.isClosed }
 
+    /// The current terminal dimensions reported by ncurses for this window.
+    public var size: TerminalSize? {
+        handle.withDescriptor { descriptor in
+            let size = CNCursesWindowAPI.size(of: descriptor)
+            return TerminalSize(rows: size.rows, columns: size.columns)
+        }
+    }
+
     /// Closes the underlying ncurses window.
     /// - Throws: ``TerminalRuntimeError`` if ncurses reports a failure while closing the window.
     public func close() throws {


### PR DESCRIPTION
## Summary
- extend the ncurses shims and Swift bridge to surface color and mouse capability information
- add terminal capability inspection, window sizing helpers, and a color palette/theming system with safe fallbacks
- expose palette access, terminal sizing, and mouse capture toggles through the runtime coordinator and app context

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_68ce6f537fd483339223b6b1b8aa1396