### PR TITLE
Add injectable ncurses environment and comprehensive tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Swift
+        uses: swift-actions/setup-swift@v1
+        with:
+          swift-version: '6.1'
+
+      - name: Swift format (lint)
+        run: swift format --lint --recursive .
+
+      - name: Build
+        run: swift build --build-tests
+
+      - name: Test
+        run: swift test

--- a/Package.swift
+++ b/Package.swift
@@ -48,6 +48,7 @@ let package = Package(
             name: "SwiftCursesKitTests",
             dependencies: [
                 "SwiftCursesKit",
+                "CNCursesSupport",
                 "DashboardDemo",
             ],
             path: "Tests/SwiftCursesKitTests"

--- a/Sources/SwiftCursesKit/Runtime/Color/TerminalColor.swift
+++ b/Sources/SwiftCursesKit/Runtime/Color/TerminalColor.swift
@@ -20,42 +20,50 @@ public struct TerminalColor: Sendable, Hashable {
 
     /// The standard ncurses black color.
     public static var black: TerminalColor {
-        TerminalColor(rawValue: CNCursesColorAPI.blackIdentifier())
+        let environment = CNCursesBridge.environment
+        return TerminalColor(rawValue: environment.color.blackIdentifier())
     }
 
     /// The standard ncurses red color.
     public static var red: TerminalColor {
-        TerminalColor(rawValue: CNCursesColorAPI.redIdentifier())
+        let environment = CNCursesBridge.environment
+        return TerminalColor(rawValue: environment.color.redIdentifier())
     }
 
     /// The standard ncurses green color.
     public static var green: TerminalColor {
-        TerminalColor(rawValue: CNCursesColorAPI.greenIdentifier())
+        let environment = CNCursesBridge.environment
+        return TerminalColor(rawValue: environment.color.greenIdentifier())
     }
 
     /// The standard ncurses yellow color.
     public static var yellow: TerminalColor {
-        TerminalColor(rawValue: CNCursesColorAPI.yellowIdentifier())
+        let environment = CNCursesBridge.environment
+        return TerminalColor(rawValue: environment.color.yellowIdentifier())
     }
 
     /// The standard ncurses blue color.
     public static var blue: TerminalColor {
-        TerminalColor(rawValue: CNCursesColorAPI.blueIdentifier())
+        let environment = CNCursesBridge.environment
+        return TerminalColor(rawValue: environment.color.blueIdentifier())
     }
 
     /// The standard ncurses magenta color.
     public static var magenta: TerminalColor {
-        TerminalColor(rawValue: CNCursesColorAPI.magentaIdentifier())
+        let environment = CNCursesBridge.environment
+        return TerminalColor(rawValue: environment.color.magentaIdentifier())
     }
 
     /// The standard ncurses cyan color.
     public static var cyan: TerminalColor {
-        TerminalColor(rawValue: CNCursesColorAPI.cyanIdentifier())
+        let environment = CNCursesBridge.environment
+        return TerminalColor(rawValue: environment.color.cyanIdentifier())
     }
 
     /// The standard ncurses white color.
     public static var white: TerminalColor {
-        TerminalColor(rawValue: CNCursesColorAPI.whiteIdentifier())
+        let environment = CNCursesBridge.environment
+        return TerminalColor(rawValue: environment.color.whiteIdentifier())
     }
 
     /// Validates whether the color value is within the specified capability bounds.

--- a/Sources/SwiftCursesKit/Runtime/Internal/CNCursesEnvironment.swift
+++ b/Sources/SwiftCursesKit/Runtime/Internal/CNCursesEnvironment.swift
@@ -1,0 +1,133 @@
+import CNCursesSupport
+import Foundation
+
+struct CNCursesEnvironment {
+    struct Runtime {
+        var bootstrap: @Sendable () throws -> Bool
+        var shutdown: @Sendable () throws -> Void
+        var isHeadless: @Sendable () -> Bool
+    }
+
+    struct Window {
+        var standardScreen: @Sendable () throws -> CNCursesWindowDescriptor
+        var destroyWindow: @Sendable (CNCursesWindowDescriptor) throws -> Void
+        var size: @Sendable (CNCursesWindowDescriptor) -> (rows: Int, columns: Int)
+        var clear: @Sendable (CNCursesWindowDescriptor) throws -> Void
+        var draw: @Sendable (String, CNCursesWindowDescriptor, Int, Int) throws -> Void
+        var stage: @Sendable (CNCursesWindowDescriptor) throws -> Void
+        var commit: @Sendable () throws -> Void
+    }
+
+    struct Input {
+        var readCharacter: @Sendable (CNCursesWindowDescriptor) -> Int32
+        var noInputCode: @Sendable () -> Int32
+    }
+
+    struct Color {
+        var hasColorSupport: @Sendable () -> Bool
+        var startColor: @Sendable () throws -> Void
+        var colorCount: @Sendable () -> Int
+        var colorPairCount: @Sendable () -> Int
+        var enableDefaultColors: @Sendable () -> Bool
+        var canChangeColor: @Sendable () -> Bool
+        var initializePair: @Sendable (Int16, Int16, Int16) throws -> Void
+        var blackIdentifier: @Sendable () -> Int16
+        var redIdentifier: @Sendable () -> Int16
+        var greenIdentifier: @Sendable () -> Int16
+        var yellowIdentifier: @Sendable () -> Int16
+        var blueIdentifier: @Sendable () -> Int16
+        var magentaIdentifier: @Sendable () -> Int16
+        var cyanIdentifier: @Sendable () -> Int16
+        var whiteIdentifier: @Sendable () -> Int16
+    }
+
+    struct Mouse {
+        var hasMouseSupport: @Sendable () -> Bool
+        var setMouseMask: @Sendable (UInt) throws -> Void
+        var allEventsMask: @Sendable () -> UInt
+        var reportPositionMask: @Sendable () -> UInt
+    }
+
+    var runtime: Runtime
+    var window: Window
+    var input: Input
+    var color: Color
+    var mouse: Mouse
+}
+
+enum CNCursesBridge {
+    private static let storage = LockedValue(CNCursesEnvironment.live)
+
+    static var environment: CNCursesEnvironment {
+        get { storage.withValue { $0 } }
+        set { storage.withValue { $0 = newValue } }
+    }
+}
+
+extension CNCursesEnvironment {
+    static var live: CNCursesEnvironment {
+        CNCursesEnvironment(
+            runtime: .init(
+                bootstrap: { try CNCursesRuntime.bootstrap() },
+                shutdown: { try CNCursesRuntime.shutdown() },
+                isHeadless: { CNCursesRuntime.isHeadless }
+            ),
+            window: .init(
+                standardScreen: { try CNCursesWindowAPI.standardScreen() },
+                destroyWindow: { try CNCursesWindowAPI.destroyWindow($0) },
+                size: { CNCursesWindowAPI.size(of: $0) },
+                clear: { try CNCursesWindowAPI.clear($0) },
+                draw: { text, descriptor, y, x in
+                    try CNCursesWindowAPI.draw(text, descriptor: descriptor, y: y, x: x)
+                },
+                stage: { try CNCursesWindowAPI.stage($0) },
+                commit: { try CNCursesWindowAPI.commitStagedUpdates() }
+            ),
+            input: .init(
+                readCharacter: { CNCursesInputAPI.readCharacter(from: $0) },
+                noInputCode: { CNCursesInputAPI.noInputCode }
+            ),
+            color: .init(
+                hasColorSupport: { CNCursesColorAPI.hasColorSupport },
+                startColor: { try CNCursesColorAPI.startColor() },
+                colorCount: { CNCursesColorAPI.colorCount() },
+                colorPairCount: { CNCursesColorAPI.colorPairCount() },
+                enableDefaultColors: { CNCursesColorAPI.enableDefaultColors() },
+                canChangeColor: { CNCursesColorAPI.canChangeColor() },
+                initializePair: { identifier, foreground, background in
+                    try CNCursesColorAPI.initializePair(
+                        identifier: identifier, foreground: foreground, background: background)
+                },
+                blackIdentifier: { CNCursesColorAPI.blackIdentifier() },
+                redIdentifier: { CNCursesColorAPI.redIdentifier() },
+                greenIdentifier: { CNCursesColorAPI.greenIdentifier() },
+                yellowIdentifier: { CNCursesColorAPI.yellowIdentifier() },
+                blueIdentifier: { CNCursesColorAPI.blueIdentifier() },
+                magentaIdentifier: { CNCursesColorAPI.magentaIdentifier() },
+                cyanIdentifier: { CNCursesColorAPI.cyanIdentifier() },
+                whiteIdentifier: { CNCursesColorAPI.whiteIdentifier() }
+            ),
+            mouse: .init(
+                hasMouseSupport: { CNCursesMouseAPI.hasMouseSupport },
+                setMouseMask: { try CNCursesMouseAPI.setMouseMask($0) },
+                allEventsMask: { CNCursesMouseAPI.allEventsMask() },
+                reportPositionMask: { CNCursesMouseAPI.reportPositionMask() }
+            )
+        )
+    }
+}
+
+private final class LockedValue<Value>: @unchecked Sendable {
+    private var value: Value
+    private let lock = NSLock()
+
+    init(_ value: Value) {
+        self.value = value
+    }
+
+    func withValue<T>(_ body: (inout Value) -> T) -> T {
+        lock.withLock {
+            body(&value)
+        }
+    }
+}

--- a/Sources/SwiftCursesKit/Runtime/Internal/ColorPairRegistry.swift
+++ b/Sources/SwiftCursesKit/Runtime/Internal/ColorPairRegistry.swift
@@ -53,21 +53,18 @@ final class ColorPairRegistry: @unchecked Sendable {
             return .allocate(identifier: identifier, capabilities: capabilities)
         }
 
+        let environment = CNCursesBridge.environment
         switch evaluation {
         case .defaultPair:
             return .default
-        case let .cached(pair):
+        case .cached(let pair):
             return pair
-        case let .allocate(identifier, capabilities):
+        case .allocate(let identifier, let capabilities):
             let components = configuration.resolvedComponents(for: capabilities)
             do {
-                try CNCursesColorAPI.initializePair(
-                    identifier: identifier,
-                    foreground: components.0,
-                    background: components.1
-                )
+                try environment.color.initializePair(identifier, components.0, components.1)
             } catch let error as CNCursesRuntimeError {
-                if case let .callFailed(name: _, code: code) = error {
+                if case .callFailed(name: _, code: let code) = error {
                     throw ColorPaletteError.ncursesCallFailed(code: code)
                 }
                 throw ColorPaletteError.ncursesCallFailed(code: -1)

--- a/Sources/SwiftCursesKit/Runtime/Internal/WindowHandle.swift
+++ b/Sources/SwiftCursesKit/Runtime/Internal/WindowHandle.swift
@@ -22,9 +22,10 @@ final class WindowHandle: @unchecked Sendable {
             guard !closed else { return }
             if ownsLifecycle, let descriptor {
                 do {
-                    try CNCursesWindowAPI.destroyWindow(descriptor)
+                    let environment = CNCursesBridge.environment
+                    try environment.window.destroyWindow(descriptor)
                 } catch let error as CNCursesRuntimeError {
-                    if case let .callFailed(name: name, code: code) = error {
+                    if case .callFailed(name: let name, code: let code) = error {
                         throw TerminalRuntimeError.ncursesCallFailed(
                             function: name.runtimeFunctionName, code: code)
                     }

--- a/Sources/SwiftCursesKit/Runtime/MouseCaptureOptions.swift
+++ b/Sources/SwiftCursesKit/Runtime/MouseCaptureOptions.swift
@@ -1,4 +1,3 @@
-import CNCursesSupport
 import Foundation
 
 /// Represents the set of mouse events that should be captured by ncurses.
@@ -12,10 +11,16 @@ public struct MouseCaptureOptions: OptionSet, Sendable {
     }
 
     /// Captures all mouse button events supported by ncurses.
-    public static let buttonEvents = MouseCaptureOptions(rawValue: CNCursesMouseAPI.allEventsMask())
+    public static var buttonEvents: MouseCaptureOptions {
+        let environment = CNCursesBridge.environment
+        return MouseCaptureOptions(rawValue: environment.mouse.allEventsMask())
+    }
 
     /// Enables reporting of mouse motion while buttons are pressed.
-    public static let motion = MouseCaptureOptions(rawValue: CNCursesMouseAPI.reportPositionMask())
+    public static var motion: MouseCaptureOptions {
+        let environment = CNCursesBridge.environment
+        return MouseCaptureOptions(rawValue: environment.mouse.reportPositionMask())
+    }
 
     /// Captures all available mouse events.
     public static let all: MouseCaptureOptions = [.buttonEvents, .motion]

--- a/Sources/SwiftCursesKit/Runtime/TerminalCapabilities.swift
+++ b/Sources/SwiftCursesKit/Runtime/TerminalCapabilities.swift
@@ -61,7 +61,8 @@ public struct TerminalCapabilities: Sendable, Equatable {
 
 enum TerminalCapabilitiesInspector {
     static func inspect() -> TerminalCapabilities {
-        guard CNCursesRuntime.isHeadless == false else {
+        let environment = CNCursesBridge.environment
+        guard environment.runtime.isHeadless() == false else {
             return .headless
         }
 
@@ -71,14 +72,14 @@ enum TerminalCapabilitiesInspector {
         var supportsDefaultColors = false
         var supportsDynamicColorChanges = false
 
-        if CNCursesColorAPI.hasColorSupport {
+        if environment.color.hasColorSupport() {
             do {
-                try CNCursesColorAPI.startColor()
+                try environment.color.startColor()
                 supportsColor = true
-                colorCount = max(CNCursesColorAPI.colorCount(), 0)
-                colorPairCount = max(CNCursesColorAPI.colorPairCount(), 0)
-                supportsDefaultColors = CNCursesColorAPI.enableDefaultColors()
-                supportsDynamicColorChanges = CNCursesColorAPI.canChangeColor()
+                colorCount = max(environment.color.colorCount(), 0)
+                colorPairCount = max(environment.color.colorPairCount(), 0)
+                supportsDefaultColors = environment.color.enableDefaultColors()
+                supportsDynamicColorChanges = environment.color.canChangeColor()
             } catch {
                 supportsColor = false
                 colorCount = 0
@@ -88,7 +89,7 @@ enum TerminalCapabilitiesInspector {
             }
         }
 
-        let supportsMouse = CNCursesMouseAPI.hasMouseSupport && !CNCursesRuntime.isHeadless
+        let supportsMouse = environment.mouse.hasMouseSupport() && !environment.runtime.isHeadless()
 
         return TerminalCapabilities(
             isHeadless: false,

--- a/Sources/SwiftCursesKit/Runtime/Window.swift
+++ b/Sources/SwiftCursesKit/Runtime/Window.swift
@@ -26,7 +26,8 @@ public final class Window: @unchecked Sendable {
     /// The current terminal dimensions reported by ncurses for this window.
     public var size: TerminalSize? {
         handle.withDescriptor { descriptor in
-            let size = CNCursesWindowAPI.size(of: descriptor)
+            let environment = CNCursesBridge.environment
+            let size = environment.window.size(descriptor)
             return TerminalSize(rows: size.rows, columns: size.columns)
         }
     }

--- a/Tests/SwiftCursesKitTests/SceneLayoutTests.swift
+++ b/Tests/SwiftCursesKitTests/SceneLayoutTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import SwiftCursesKit
+
+final class SceneLayoutTests: XCTestCase {
+    override func tearDown() {
+        super.tearDown()
+        CNCursesBridge.environment = .live
+    }
+
+    func testVStackAppliesSpacingAndExpandsWidth() throws {
+        let environmentDouble = TestCNCursesEnvironment()
+        environmentDouble.windowSize = (rows: 6, columns: 12)
+        CNCursesBridge.environment = environmentDouble.makeEnvironment()
+
+        let screen = environmentDouble.makeScreen()
+        let widgetA = RecordingWidget(label: "A", measured: LayoutSize(width: 4, height: 2))
+        let widgetB = RecordingWidget(label: "B", measured: LayoutSize(width: 3, height: 2))
+        let scene = VStack(spacing: 1) {
+            WidgetView(widgetA)
+            WidgetView(widgetB)
+        }
+
+        let renderer = SceneRenderer()
+        try renderer.render(scene: scene, on: screen)
+
+        XCTAssertEqual(environmentDouble.drawCalls.count, 2)
+        XCTAssertEqual(environmentDouble.drawCalls[0].origin, LayoutPoint(x: 0, y: 0))
+        XCTAssertEqual(environmentDouble.drawCalls[1].origin, LayoutPoint(x: 0, y: 5))
+        let verticalLabels = environmentDouble.drawCalls.map { command in
+            command.text.trimmingCharacters(in: .whitespaces)
+        }
+        XCTAssertEqual(verticalLabels, ["A", "B"])
+        XCTAssertEqual(environmentDouble.clearedCount, 1)
+        XCTAssertEqual(environmentDouble.stagedCount, 1)
+        XCTAssertEqual(environmentDouble.commitCount, 1)
+    }
+
+    func testSplitDistributesSpaceAccordingToFraction() throws {
+        let environmentDouble = TestCNCursesEnvironment()
+        environmentDouble.windowSize = (rows: 4, columns: 20)
+        CNCursesBridge.environment = environmentDouble.makeEnvironment()
+
+        let screen = environmentDouble.makeScreen()
+        let leading = RecordingWidget(label: "Leading", measured: LayoutSize(width: 5, height: 1))
+        let trailing = RecordingWidget(label: "Trailing", measured: LayoutSize(width: 5, height: 1))
+        let scene = Split(.vertical, fraction: 0.25) {
+            WidgetView(leading)
+        } trailing: {
+            WidgetView(trailing)
+        }
+
+        let renderer = SceneRenderer()
+        try renderer.render(scene: scene, on: screen)
+
+        XCTAssertEqual(environmentDouble.drawCalls.count, 2)
+        XCTAssertEqual(environmentDouble.drawCalls[0].origin.x, 0)
+        XCTAssertEqual(environmentDouble.drawCalls[1].origin.x, 5)
+        let splitLabels = environmentDouble.drawCalls.map { command in
+            command.text.trimmingCharacters(in: .whitespaces)
+        }
+        XCTAssertEqual(splitLabels, ["Leadi", "Trail"])
+    }
+}
+
+private struct RecordingWidget: Widget {
+    var label: String
+    var measured: LayoutSize
+
+    func measure(in constraints: LayoutConstraints) -> LayoutSize {
+        LayoutSize(
+            width: min(constraints.maxWidth, max(measured.width, constraints.minWidth)),
+            height: min(constraints.maxHeight, max(measured.height, constraints.minHeight))
+        )
+    }
+
+    func render(in frame: LayoutRect, buffer: inout RenderBuffer) {
+        guard frame.size.width > 0, frame.size.height > 0 else { return }
+        buffer.write(label, at: frame.origin, maxWidth: frame.size.width)
+    }
+}

--- a/Tests/SwiftCursesKitTests/TerminalAppTests.swift
+++ b/Tests/SwiftCursesKitTests/TerminalAppTests.swift
@@ -2,6 +2,22 @@ import XCTest
 @testable import SwiftCursesKit
 
 final class TerminalAppTests: XCTestCase {
+    private var environmentDouble: TestCNCursesEnvironment!
+
+    override func setUp() {
+        super.setUp()
+        environmentDouble = TestCNCursesEnvironment()
+        environmentDouble.runtimeIsHeadless = true
+        environmentDouble.noInputCode = -1
+        CNCursesBridge.environment = environmentDouble.makeEnvironment()
+    }
+
+    override func tearDown() {
+        CNCursesBridge.environment = .live
+        environmentDouble = nil
+        super.tearDown()
+    }
+
     func testRunReturnsBanner() async throws {
         let app = StaticTerminalApp()
         let output = try await app.run()

--- a/Tests/SwiftCursesKitTests/TerminalCapabilitiesTests.swift
+++ b/Tests/SwiftCursesKitTests/TerminalCapabilitiesTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import SwiftCursesKit
+
+final class TerminalCapabilitiesTests: XCTestCase {
+    override func tearDown() {
+        super.tearDown()
+        CNCursesBridge.environment = .live
+    }
+
+    func testInspectorFallsBackWhenColorInitializationFails() {
+        enum SampleError: Error { case failure }
+
+        let environmentDouble = TestCNCursesEnvironment()
+        environmentDouble.runtimeIsHeadless = false
+        environmentDouble.colorHasSupport = true
+        environmentDouble.colorStartThrows = SampleError.failure
+        CNCursesBridge.environment = environmentDouble.makeEnvironment()
+
+        let capabilities = TerminalCapabilitiesInspector.inspect()
+        XCTAssertFalse(capabilities.supportsColor)
+        XCTAssertEqual(capabilities.colorCount, 0)
+        XCTAssertEqual(capabilities.colorPairCount, 0)
+        XCTAssertFalse(capabilities.supportsDefaultColors)
+        XCTAssertFalse(capabilities.supportsDynamicColorChanges)
+    }
+
+    func testInspectorReportsMouseSupportWhenAvailable() {
+        let environmentDouble = TestCNCursesEnvironment()
+        environmentDouble.runtimeIsHeadless = false
+        environmentDouble.mouseHasSupport = true
+        CNCursesBridge.environment = environmentDouble.makeEnvironment()
+
+        let capabilities = TerminalCapabilitiesInspector.inspect()
+        XCTAssertTrue(capabilities.supportsMouse)
+    }
+
+    func testInspectorReportsHeadlessWhenRuntimeIsHeadless() {
+        let environmentDouble = TestCNCursesEnvironment()
+        environmentDouble.runtimeIsHeadless = true
+        CNCursesBridge.environment = environmentDouble.makeEnvironment()
+
+        let capabilities = TerminalCapabilitiesInspector.inspect()
+        XCTAssertTrue(capabilities.isHeadless)
+        XCTAssertFalse(capabilities.supportsMouse)
+    }
+}

--- a/Tests/SwiftCursesKitTests/TerminalRuntimeCoordinatorTests.swift
+++ b/Tests/SwiftCursesKitTests/TerminalRuntimeCoordinatorTests.swift
@@ -1,0 +1,132 @@
+import XCTest
+@testable import SwiftCursesKit
+
+final class TerminalRuntimeCoordinatorTests: XCTestCase {
+    override func tearDown() {
+        super.tearDown()
+        CNCursesBridge.environment = .live
+    }
+
+    func testTranslateKeyCodeReturnsPrintableCharacters() {
+        let coordinator = TerminalRuntimeCoordinator.shared
+        let code = Int32(Character("z").asciiValue!)
+        let event = coordinator._testTranslateKeyCode(code)
+        guard case .character(let character)? = event else {
+            return XCTFail("Expected character event")
+        }
+        XCTAssertEqual(character, "z")
+        XCTAssertNil(coordinator._testTranslateKeyCode(-1))
+        XCTAssertNil(coordinator._testTranslateKeyCode(0x80))
+    }
+
+    func testWindowHandleCloseDestroysDescriptorOnce() throws {
+        let environmentDouble = TestCNCursesEnvironment()
+        CNCursesBridge.environment = environmentDouble.makeEnvironment()
+
+        guard
+            let descriptor = environmentDouble.makeScreen()
+                .rootWindow
+                .withDescriptor({ $0 })
+        else {
+            return XCTFail("Expected descriptor")
+        }
+        let handle = WindowHandle(descriptor: descriptor, ownsLifecycle: true)
+        XCTAssertFalse(handle.isClosed)
+        try handle.close()
+        XCTAssertTrue(handle.isClosed)
+        XCTAssertEqual(environmentDouble.windowDestroyedDescriptors.count, 1)
+        try handle.close()
+        XCTAssertEqual(environmentDouble.windowDestroyedDescriptors.count, 1)
+    }
+
+    func testWindowAutoCloseInvokesDestroy() throws {
+        let environmentDouble = TestCNCursesEnvironment()
+        CNCursesBridge.environment = environmentDouble.makeEnvironment()
+
+        guard
+            let descriptor = environmentDouble.makeScreen()
+                .rootWindow
+                .withDescriptor({ $0 })
+        else {
+            return XCTFail("Expected descriptor")
+        }
+        var window: Window? = Window(
+            handle: WindowHandle(descriptor: descriptor, ownsLifecycle: true),
+            autoClose: true
+        )
+        XCTAssertNotNil(window)
+        window = nil
+        XCTAssertEqual(environmentDouble.windowDestroyedDescriptors.count, 1)
+    }
+
+    func testRuntimeProcessesKeyAndTickEvents() async throws {
+        let environmentDouble = TestCNCursesEnvironment()
+        environmentDouble.windowSize = (rows: 8, columns: 40)
+        environmentDouble.colorHasSupport = false
+        environmentDouble.mouseHasSupport = true
+        environmentDouble.inputQueue = [Int32(Character("q").asciiValue!)]
+        environmentDouble.noInputCode = -1
+        CNCursesBridge.environment = environmentDouble.makeEnvironment()
+
+        let recorder = EventRecorder()
+        let app = IntegrationTestApp(recorder: recorder)
+        let banner = try await app.run()
+        XCTAssertEqual(banner, app.banner)
+
+        let events = await recorder.events
+        XCTAssertEqual(events.count, 2)
+        guard case .key(.character(let character)) = events.first else {
+            return XCTFail("Expected key event")
+        }
+        XCTAssertEqual(character, "q")
+        guard case .tick = events.last else {
+            return XCTFail("Expected tick event")
+        }
+
+        XCTAssertEqual(environmentDouble.runtimeBootstrapCount, 1)
+        XCTAssertEqual(environmentDouble.runtimeShutdownCount, 1)
+        XCTAssertGreaterThan(environmentDouble.drawCalls.count, 0)
+        XCTAssertEqual(environmentDouble.clearedCount, 1)
+        XCTAssertEqual(environmentDouble.stagedCount, 1)
+        XCTAssertEqual(environmentDouble.commitCount, 1)
+    }
+
+    func testMouseCaptureOptionsReflectEnvironmentMasks() {
+        let environmentDouble = TestCNCursesEnvironment()
+        environmentDouble.mouseAllEventsMask = 0x1F
+        environmentDouble.mouseReportPositionMask = 0xF1
+        CNCursesBridge.environment = environmentDouble.makeEnvironment()
+
+        XCTAssertEqual(MouseCaptureOptions.buttonEvents.rawValue, 0x1F)
+        XCTAssertEqual(MouseCaptureOptions.motion.rawValue, 0xF1)
+    }
+}
+
+private actor EventRecorder {
+    private(set) var events: [Event] = []
+
+    func record(_ event: Event) {
+        events.append(event)
+    }
+}
+
+private struct IntegrationTestApp: TerminalApp {
+    var recorder: EventRecorder
+    var banner: String { "Integration" }
+
+    var body: some Scene {
+        Screen {
+            Title("Integration")
+        }
+    }
+
+    mutating func onEvent(_ event: Event, context: AppContext) async {
+        await recorder.record(event)
+        switch event {
+        case .tick:
+            await context.quit()
+        case .key:
+            break
+        }
+    }
+}

--- a/Tests/SwiftCursesKitTests/TestSupport/TestCNCursesEnvironment.swift
+++ b/Tests/SwiftCursesKitTests/TestSupport/TestCNCursesEnvironment.swift
@@ -1,0 +1,178 @@
+@testable import CNCursesSupport
+import XCTest
+@testable import SwiftCursesKit
+
+final class TestCNCursesEnvironment: @unchecked Sendable {
+    struct DrawCall: Equatable {
+        var text: String
+        var origin: LayoutPoint
+    }
+
+    private(set) var runtimeBootstrapCount = 0
+    private(set) var runtimeShutdownCount = 0
+    var runtimeIsHeadless = false
+    var runtimeBootstrapError: Error?
+    var runtimeShutdownError: Error?
+
+    private(set) var standardScreenCallCount = 0
+    private(set) var windowDestroyedDescriptors: [CNCursesWindowDescriptor] = []
+    var windowSize: (rows: Int, columns: Int) = (24, 80)
+    private(set) var clearedCount = 0
+    private(set) var stagedCount = 0
+    private(set) var commitCount = 0
+    private(set) var drawCalls: [DrawCall] = []
+
+    var inputQueue: [Int32] = []
+    var noInputCode: Int32 = -1
+
+    var colorHasSupport = false
+    var colorStartThrows: Error?
+    var colorCountValue = 0
+    var colorPairCountValue = 0
+    var colorEnableDefaultColors = false
+    var colorCanChange = false
+    private(set) var initializedPairs: [(Int16, Int16, Int16)] = []
+
+    var mouseHasSupport = false
+    private(set) var mouseMasks: [UInt] = []
+    var mouseAllEventsMask: UInt = 0
+    var mouseReportPositionMask: UInt = 0
+
+    private let descriptor: CNCursesWindowDescriptor
+
+    init() {
+        let rawPointer = UnsafeMutableRawPointer(bitPattern: 0x1234)!
+        descriptor = CNCursesWindowDescriptor(rawValue: rawPointer)
+    }
+
+    func resetCounters() {
+        runtimeBootstrapCount = 0
+        runtimeShutdownCount = 0
+        standardScreenCallCount = 0
+        windowDestroyedDescriptors.removeAll()
+        clearedCount = 0
+        stagedCount = 0
+        commitCount = 0
+        drawCalls.removeAll()
+        initializedPairs.removeAll()
+        mouseMasks.removeAll()
+    }
+
+    func makeEnvironment() -> CNCursesEnvironment {
+        CNCursesEnvironment(
+            runtime: .init(
+                bootstrap: { [weak self] in
+                    guard let self else { return true }
+                    if let error = self.runtimeBootstrapError {
+                        throw error
+                    }
+                    self.runtimeBootstrapCount += 1
+                    return true
+                },
+                shutdown: { [weak self] in
+                    guard let self else { return }
+                    if let error = self.runtimeShutdownError {
+                        throw error
+                    }
+                    self.runtimeShutdownCount += 1
+                },
+                isHeadless: { [weak self] in
+                    self?.runtimeIsHeadless ?? false
+                }
+            ),
+            window: .init(
+                standardScreen: { [weak self] in
+                    guard let self else {
+                        let rawPointer = UnsafeMutableRawPointer(bitPattern: 0x1)!
+                        return CNCursesWindowDescriptor(rawValue: rawPointer)
+                    }
+                    self.standardScreenCallCount += 1
+                    return self.descriptor
+                },
+                destroyWindow: { [weak self] descriptor in
+                    self?.windowDestroyedDescriptors.append(descriptor)
+                },
+                size: { [weak self] _ in
+                    guard let self else { return (0, 0) }
+                    return self.windowSize
+                },
+                clear: { [weak self] _ in
+                    self?.clearedCount += 1
+                },
+                draw: { [weak self] text, _, y, x in
+                    let origin = LayoutPoint(x: x, y: y)
+                    self?.drawCalls.append(DrawCall(text: text, origin: origin))
+                },
+                stage: { [weak self] _ in
+                    self?.stagedCount += 1
+                },
+                commit: { [weak self] in
+                    self?.commitCount += 1
+                }
+            ),
+            input: .init(
+                readCharacter: { [weak self] _ in
+                    guard let self else { return 0 }
+                    if !self.inputQueue.isEmpty {
+                        return self.inputQueue.removeFirst()
+                    }
+                    return self.noInputCode
+                },
+                noInputCode: { [weak self] in
+                    self?.noInputCode ?? -1
+                }
+            ),
+            color: .init(
+                hasColorSupport: { [weak self] in
+                    self?.colorHasSupport ?? false
+                },
+                startColor: { [weak self] in
+                    if let error = self?.colorStartThrows {
+                        throw error
+                    }
+                },
+                colorCount: { [weak self] in
+                    self?.colorCountValue ?? 0
+                },
+                colorPairCount: { [weak self] in
+                    self?.colorPairCountValue ?? 0
+                },
+                enableDefaultColors: { [weak self] in
+                    self?.colorEnableDefaultColors ?? false
+                },
+                canChangeColor: { [weak self] in
+                    self?.colorCanChange ?? false
+                },
+                initializePair: { [weak self] identifier, foreground, background in
+                    self?.initializedPairs.append((identifier, foreground, background))
+                },
+                blackIdentifier: { 0 },
+                redIdentifier: { 1 },
+                greenIdentifier: { 2 },
+                yellowIdentifier: { 3 },
+                blueIdentifier: { 4 },
+                magentaIdentifier: { 5 },
+                cyanIdentifier: { 6 },
+                whiteIdentifier: { 7 }
+            ),
+            mouse: .init(
+                hasMouseSupport: { [weak self] in
+                    self?.mouseHasSupport ?? false
+                },
+                setMouseMask: { [weak self] mask in
+                    self?.mouseMasks.append(mask)
+                },
+                allEventsMask: { [weak self] in
+                    self?.mouseAllEventsMask ?? 0
+                },
+                reportPositionMask: { [weak self] in
+                    self?.mouseReportPositionMask ?? 0
+                }
+            )
+        )
+    }
+
+    func makeScreen() -> TerminalScreen {
+        TerminalScreen(rootHandle: WindowHandle(descriptor: descriptor, ownsLifecycle: false))
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a CNCursesBridge environment wrapper so ncurses calls can be replaced by test doubles
- expand SwiftCursesKit tests with layout, capability, runtime integration, and support utilities powered by the new fakes
- wire a CI workflow that enforces `swift build`, `swift test`, and `swift format lint` before merges

## Testing
- swift format lint --configuration .swift-format.json --recursive .
- swift build
- swift test

------
https://chatgpt.com/codex/tasks/task_b_68cea4d9523c8333a86fb24aea0d7c50