### PR TITLE
Remove implementation-only imports

### DIFF
--- a/Sources/CNCursesSupport/Swift/Capabilities.swift
+++ b/Sources/CNCursesSupport/Swift/Capabilities.swift
@@ -1,4 +1,4 @@
-@_implementationOnly import CNCursesSupportShims
+import CNCursesSupportShims
 import Foundation
 
 package enum CNCursesColorAPI {

--- a/Sources/CNCursesSupport/Swift/Input.swift
+++ b/Sources/CNCursesSupport/Swift/Input.swift
@@ -1,4 +1,4 @@
-@_implementationOnly import CNCursesSupportShims
+import CNCursesSupportShims
 
 package enum CNCursesInputAPI {
     package static func readCharacter(from descriptor: CNCursesWindowDescriptor) -> Int32 {

--- a/Sources/CNCursesSupport/Swift/Runtime.swift
+++ b/Sources/CNCursesSupport/Swift/Runtime.swift
@@ -1,4 +1,4 @@
-@_implementationOnly import CNCursesSupportShims
+import CNCursesSupportShims
 import Foundation
 
 #if os(Linux)

--- a/Sources/CNCursesSupport/Swift/Windows.swift
+++ b/Sources/CNCursesSupport/Swift/Windows.swift
@@ -1,4 +1,4 @@
-@_implementationOnly import CNCursesSupportShims
+import CNCursesSupportShims
 import Foundation
 
 package struct CNCursesWindowDescriptor: @unchecked Sendable {


### PR DESCRIPTION
## Summary
- replace the `_implementationOnly` imports of `CNCursesSupportShims` with standard imports across the CNCurses Swift wrappers to eliminate build warnings

## Testing
- swift build
- swift test

------
https://chatgpt.com/codex/tasks/task_b_68cecaf8697c833391e4da88238ff04b