### PR TITLE
Fix ncurses header detection

### DIFF
--- a/Sources/CNCursesSupport/Shims/include/CNCursesSupportShims.h
+++ b/Sources/CNCursesSupport/Shims/include/CNCursesSupportShims.h
@@ -3,7 +3,13 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <ncursesw/curses.h>
+#if __has_include(<ncursesw/curses.h>)
+#    include <ncursesw/curses.h>
+#elif __has_include(<curses.h>)
+#    include <curses.h>
+#else
+#    error "Unable to locate an ncurses header."
+#endif
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
## Summary
- conditionally include the Homebrew ncursesw header only when it exists and otherwise fall back to the system curses header

## Testing
- swift build
- swift test

------
https://chatgpt.com/codex/tasks/task_b_68ceccac993083339ee339707b1d927f