### PR TITLE
Ensure ncurses headers are detected correctly

### DIFF
--- a/Sources/CNCursesSupport/Shims/include/CNCursesSupportShims.h
+++ b/Sources/CNCursesSupport/Shims/include/CNCursesSupportShims.h
@@ -5,10 +5,12 @@
 #include <stdint.h>
 #if __has_include(<ncursesw/curses.h>)
 #    include <ncursesw/curses.h>
-#elif __has_include(<curses.h>)
-#    include <curses.h>
+#elif __has_include(<ncurses/curses.h>)
+#    include <ncurses/curses.h>
+#elif __has_include(<ncurses.h>)
+#    include <ncurses.h>
 #else
-#    error "Unable to locate an ncurses header."
+#    error "Unable to locate an ncurses header. SwiftCursesKit requires ncurses with wide-character support."
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary
- prefer ncurses-wide headers in the shim before falling back to plain ncurses includes
- emit a clearer error when no ncurses headers are found so macOS builds avoid the system curses headers

## Testing
- swift build
- swift test
- swift run DashboardDemo --recording

------
https://chatgpt.com/codex/tasks/task_b_68cecdf00bc8833381e3f09abd75e322