### PR TITLE
Decouple macOS runtime from Darwin curses imports

### DIFF
--- a/Sources/CNCursesSupport/Shims/include/CNCursesSupportShims.h
+++ b/Sources/CNCursesSupport/Shims/include/CNCursesSupportShims.h
@@ -5,6 +5,9 @@
 #include <stdint.h>
 
 #if defined(__APPLE__)
+#    include <locale.h>
+#    include <stdlib.h>
+#    include <unistd.h>
 #    if __has_include(<ncurses.h>)
 #        include <ncurses.h>
 #    elif __has_include(<ncursesw/curses.h>)
@@ -202,6 +205,24 @@ static inline int32_t cncurses_error(void) {
 static inline bool cncurses_is_endwin(void) {
     return isendwin() ? true : false;
 }
+
+#if defined(__APPLE__)
+static inline int32_t cncurses_lc_all(void) {
+    return (int32_t)LC_ALL;
+}
+
+static inline const char *cncurses_setlocale(int category, const char *locale) {
+    return setlocale(category, locale);
+}
+
+static inline bool cncurses_isatty(int fileDescriptor) {
+    return isatty(fileDescriptor) ? true : false;
+}
+
+static inline int32_t cncurses_register_exit_hook(void (*handler)(void)) {
+    return (int32_t)atexit(handler);
+}
+#endif
 
 #ifdef __cplusplus
 }

--- a/Sources/CNCursesSupport/Swift/Runtime.swift
+++ b/Sources/CNCursesSupport/Swift/Runtime.swift
@@ -2,188 +2,190 @@ import CNCursesSupportShims
 import Foundation
 
 #if os(Linux)
-    import Glibc
-#else
-    import Darwin.C
+  import Glibc
 #endif
 
 /// Errors that can be thrown while configuring the ncurses runtime.
 package enum CNCursesRuntimeError: Error, Equatable {
-    /// Indicates that the process locale could not be configured for wide characters.
-    case localeUnavailable
-    /// The ncurses library failed to produce a usable screen handle.
-    case initializationFailed
-    /// A specific ncurses call returned an error code.
-    case callFailed(name: StaticString, code: Int32)
+  /// Indicates that the process locale could not be configured for wide characters.
+  case localeUnavailable
+  /// The ncurses library failed to produce a usable screen handle.
+  case initializationFailed
+  /// A specific ncurses call returned an error code.
+  case callFailed(name: StaticString, code: Int32)
 
-    package static func == (lhs: CNCursesRuntimeError, rhs: CNCursesRuntimeError) -> Bool {
-        switch (lhs, rhs) {
-        case (.localeUnavailable, .localeUnavailable),
-            (.initializationFailed, .initializationFailed):
-            return true
-        case let (
-            .callFailed(name: lhsName, code: lhsCode), .callFailed(name: rhsName, code: rhsCode)
-        ):
-            return lhsCode == rhsCode && lhsName.asComparableKey == rhsName.asComparableKey
-        default:
-            return false
-        }
+  package static func == (lhs: CNCursesRuntimeError, rhs: CNCursesRuntimeError) -> Bool {
+    switch (lhs, rhs) {
+    case (.localeUnavailable, .localeUnavailable),
+      (.initializationFailed, .initializationFailed):
+      return true
+    case let (
+      .callFailed(name: lhsName, code: lhsCode), .callFailed(name: rhsName, code: rhsCode)
+    ):
+      return lhsCode == rhsCode && lhsName.asComparableKey == rhsName.asComparableKey
+    default:
+      return false
     }
+  }
 }
 
 package enum CNCursesRuntime {
-    private static let state = CNCursesRuntimeState()
+  private static let state = CNCursesRuntimeState()
 
-    /// Prepares the terminal environment for interactive rendering.
-    /// - Returns: `true` when initialization succeeds; otherwise throws.
-    package static func bootstrap() throws -> Bool {
-        try state.bootstrap()
-        return true
-    }
+  /// Prepares the terminal environment for interactive rendering.
+  /// - Returns: `true` when initialization succeeds; otherwise throws.
+  package static func bootstrap() throws -> Bool {
+    try state.bootstrap()
+    return true
+  }
 
-    /// Restores the terminal to its previous state.
-    package static func shutdown() throws {
-        try state.shutdown()
-    }
+  /// Restores the terminal to its previous state.
+  package static func shutdown() throws {
+    try state.shutdown()
+  }
 
-    /// Indicates whether the runtime is operating without a backing terminal.
-    package static var isHeadless: Bool {
-        state.isHeadlessFlag
-    }
+  /// Indicates whether the runtime is operating without a backing terminal.
+  package static var isHeadless: Bool {
+    state.isHeadlessFlag
+  }
 }
 
 private final class CNCursesRuntimeState: @unchecked Sendable {
-    private var screen: CNCursesWindow?
-    private var isHeadless = false
-    private var exitHookRegistered = false
-    private let lock = NSLock()
+  private var screen: CNCursesWindow?
+  private var isHeadless = false
+  private var exitHookRegistered = false
+  private let lock = NSLock()
 
-    func bootstrap() throws {
-        try lock.withLock {
-            if screen != nil || isHeadless {
-                return
-            }
+  func bootstrap() throws {
+    try lock.withLock {
+      if screen != nil || isHeadless {
+        return
+      }
 
-            if !TerminalCapabilities.isInteractive {
-                isHeadless = true
-                return
-            }
+      if !TerminalCapabilities.isInteractive {
+        isHeadless = true
+        return
+      }
 
-            try LocaleConfigurator.ensureWideCharacterLocale()
+      try LocaleConfigurator.ensureWideCharacterLocale()
 
-            let newScreen = try CNCursesWindow.standardScreen()
-            do {
-                try newScreen.prepareForInteractiveUse()
-            } catch {
-                _ = cncurses_endwin()
-                throw error
-            }
+      let newScreen = try CNCursesWindow.standardScreen()
+      do {
+        try newScreen.prepareForInteractiveUse()
+      } catch {
+        _ = cncurses_endwin()
+        throw error
+      }
 
-            screen = newScreen
-            registerExitHookIfNeeded()
-        }
+      screen = newScreen
+      registerExitHookIfNeeded()
     }
+  }
 
-    func shutdown() throws {
-        try lock.withLock {
-            if isHeadless {
-                isHeadless = false
-                return
-            }
+  func shutdown() throws {
+    try lock.withLock {
+      if isHeadless {
+        isHeadless = false
+        return
+      }
 
-            guard screen != nil else {
-                return
-            }
-            try CNCursesCall.check(result: cncurses_endwin(), name: "endwin")
-            screen = nil
-        }
+      guard screen != nil else {
+        return
+      }
+      try CNCursesCall.check(result: cncurses_endwin(), name: "endwin")
+      screen = nil
     }
+  }
 
-    private func registerExitHookIfNeeded() {
-        guard !exitHookRegistered else {
-            return
-        }
-        atexit(swiftCNCursesCleanup)
-        exitHookRegistered = true
+  private func registerExitHookIfNeeded() {
+    guard !exitHookRegistered else {
+      return
     }
+    #if os(Linux)
+      Glibc.atexit(swiftCNCursesCleanup)
+    #else
+      _ = cncurses_register_exit_hook(swiftCNCursesCleanup)
+    #endif
+    exitHookRegistered = true
+  }
 
-    var isHeadlessFlag: Bool {
-        lock.withLock { isHeadless }
-    }
+  var isHeadlessFlag: Bool {
+    lock.withLock { isHeadless }
+  }
 }
 
 private struct CNCursesWindow {
-    let rawPointer: UnsafeMutableRawPointer
+  let rawPointer: UnsafeMutableRawPointer
 
-    static func standardScreen() throws -> CNCursesWindow {
-        guard let pointer = cncurses_initscr() else {
-            throw CNCursesRuntimeError.initializationFailed
-        }
-        return CNCursesWindow(rawPointer: pointer)
+  static func standardScreen() throws -> CNCursesWindow {
+    guard let pointer = cncurses_initscr() else {
+      throw CNCursesRuntimeError.initializationFailed
     }
+    return CNCursesWindow(rawPointer: pointer)
+  }
 
-    func prepareForInteractiveUse() throws {
-        try CNCursesCall.check(result: cncurses_cbreak(), name: "cbreak")
-        try CNCursesCall.check(result: cncurses_noecho(), name: "noecho")
-        try CNCursesCall.check(result: cncurses_keypad(rawPointer, true), name: "keypad")
-        try CNCursesCall.check(result: cncurses_nodelay(rawPointer, true), name: "nodelay")
-        try CNCursesCall.check(result: cncurses_erase(), name: "erase")
-        try CNCursesCall.check(result: cncurses_refresh(), name: "refresh")
-    }
+  func prepareForInteractiveUse() throws {
+    try CNCursesCall.check(result: cncurses_cbreak(), name: "cbreak")
+    try CNCursesCall.check(result: cncurses_noecho(), name: "noecho")
+    try CNCursesCall.check(result: cncurses_keypad(rawPointer, true), name: "keypad")
+    try CNCursesCall.check(result: cncurses_nodelay(rawPointer, true), name: "nodelay")
+    try CNCursesCall.check(result: cncurses_erase(), name: "erase")
+    try CNCursesCall.check(result: cncurses_refresh(), name: "refresh")
+  }
 }
 
 private enum LocaleConfigurator {
-    static func ensureWideCharacterLocale() throws {
-        #if os(Linux)
-            let result = Glibc.setlocale(LC_ALL, "")
-        #else
-            let result = setlocale(LC_ALL, "")
-        #endif
-        guard result != nil else {
-            throw CNCursesRuntimeError.localeUnavailable
-        }
+  static func ensureWideCharacterLocale() throws {
+    #if os(Linux)
+      let result = Glibc.setlocale(LC_ALL, "")
+    #else
+      let result = cncurses_setlocale(cncurses_lc_all(), "")
+    #endif
+    guard result != nil else {
+      throw CNCursesRuntimeError.localeUnavailable
     }
+  }
 }
 
 package enum CNCursesCall {
-    private static let successCode = cncurses_ok()
+  private static let successCode = cncurses_ok()
 
-    static func check(result: Int32, name: StaticString) throws {
-        if result == successCode {
-            return
-        }
-        throw CNCursesRuntimeError.callFailed(name: name, code: result)
+  static func check(result: Int32, name: StaticString) throws {
+    if result == successCode {
+      return
     }
+    throw CNCursesRuntimeError.callFailed(name: name, code: result)
+  }
 }
 
 private enum TerminalCapabilities {
-    static var isInteractive: Bool {
-        #if os(Linux)
-            return Glibc.isatty(STDIN_FILENO) != 0 && Glibc.isatty(STDOUT_FILENO) != 0
-        #else
-            return isatty(STDIN_FILENO) != 0 && isatty(STDOUT_FILENO) != 0
-        #endif
-    }
+  static var isInteractive: Bool {
+    #if os(Linux)
+      return Glibc.isatty(STDIN_FILENO) != 0 && Glibc.isatty(STDOUT_FILENO) != 0
+    #else
+      return cncurses_isatty(STDIN_FILENO) && cncurses_isatty(STDOUT_FILENO)
+    #endif
+  }
 }
 
 extension NSLock {
-    @inline(__always)
-    fileprivate func withLock<T>(_ body: () throws -> T) rethrows -> T {
-        lock()
-        defer { unlock() }
-        return try body()
-    }
+  @inline(__always)
+  fileprivate func withLock<T>(_ body: () throws -> T) rethrows -> T {
+    lock()
+    defer { unlock() }
+    return try body()
+  }
 }
 
 @_cdecl("swiftCNCursesCleanup")
 private func swiftCNCursesCleanup() {
-    if !cncurses_is_endwin() {
-        _ = cncurses_endwin()
-    }
+  if !cncurses_is_endwin() {
+    _ = cncurses_endwin()
+  }
 }
 
 extension StaticString {
-    fileprivate var asComparableKey: String {
-        String(describing: self)
-    }
+  fileprivate var asComparableKey: String {
+    String(describing: self)
+  }
 }


### PR DESCRIPTION
## Summary
- stop the Swift runtime from importing Darwin.C and rely on CNCursesSupport shims on macOS
- extend the shim header to expose locale, tty, and exit helpers when building on Apple platforms
- switch runtime locale and terminal detection logic to use the new shims while keeping the Glibc code path on Linux

## Testing
- swift build
- swift test

------
https://chatgpt.com/codex/tasks/task_b_68ced2454a088333ae5387be6a81f8f0