### PR TITLE
Prefer Homebrew ncursesw headers on Apple

### DIFF
--- a/Sources/CNCursesSupport/Shims/include/CNCursesSupportShims.h
+++ b/Sources/CNCursesSupport/Shims/include/CNCursesSupportShims.h
@@ -8,10 +8,12 @@
 #    include <locale.h>
 #    include <stdlib.h>
 #    include <unistd.h>
-#    if __has_include(<ncurses.h>)
-#        include <ncurses.h>
-#    elif __has_include(<ncursesw/curses.h>)
+#    if __has_include(<ncursesw/curses.h>)
 #        include <ncursesw/curses.h>
+#    elif __has_include(<ncurses.h>)
+#        include <ncurses.h>
+#    elif __has_include(<ncurses/curses.h>)
+#        include <ncurses/curses.h>
 #    else
 #        error "Unable to locate Homebrew ncurses headers. Install ncurses with wide-character support (brew install ncurses)."
 #    endif


### PR DESCRIPTION
## Summary
- prefer the Homebrew-provided `ncursesw/curses.h` header when compiling on Apple platforms
- retain fallbacks to SDK or legacy include locations only if the wide-character header is unavailable

## Testing
- swift build
- swift test

------
https://chatgpt.com/codex/tasks/task_b_68ced3a368488333bf9553d2b8479e76