### PR TITLE
Adjust ncurses linking for Darwin

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,15 +27,14 @@ let package = Package(
             dependencies: ["CNCursesSupportShims"],
             path: "Sources/CNCursesSupport/Swift",
             linkerSettings: [
-                .linkedLibrary("ncursesw")
+                .linkedLibrary("ncurses", .when(platforms: [.macOS])),
+                .linkedLibrary("ncursesw", .when(platforms: [.linux]))
             ]
         ),
         .systemLibrary(
             name: "CNCursesSupportShims",
             path: "Sources/CNCursesSupport/Shims",
-            pkgConfig: "ncursesw",
             providers: [
-                .brew(["ncurses"]),
                 .apt(["libncursesw5-dev"]),
             ]
         ),

--- a/Sources/CNCursesSupport/Shims/module.modulemap
+++ b/Sources/CNCursesSupport/Shims/module.modulemap
@@ -1,5 +1,4 @@
 module CNCursesSupportShims [system] {
     header "include/CNCursesSupportShims.h"
-    link "ncursesw"
     export *
 }


### PR DESCRIPTION
## Summary
- update CNCursesSupport linker settings to use libncurses on macOS and libncursesw on Linux
- simplify the CNCursesSupportShims system library declaration to avoid Homebrew-specific metadata
- rely on SwiftPM linker settings and remove the explicit ncursesw link directive from the module map

## Testing
- swift build
- swift test

------
https://chatgpt.com/codex/tasks/task_b_68cedcbb5f20833398262f47e07edd1f