### PR TITLE
Use macOS SDK curses headers in shim

### DIFF
--- a/Sources/CNCursesSupport/Shims/include/CNCursesSupportShims.h
+++ b/Sources/CNCursesSupport/Shims/include/CNCursesSupportShims.h
@@ -8,14 +8,10 @@
 #    include <locale.h>
 #    include <stdlib.h>
 #    include <unistd.h>
-#    if __has_include(<ncursesw/curses.h>)
-#        include <ncursesw/curses.h>
-#    elif __has_include(<ncurses.h>)
-#        include <ncurses.h>
-#    elif __has_include(<ncurses/curses.h>)
-#        include <ncurses/curses.h>
+#    if __has_include(<curses.h>)
+#        include <curses.h>
 #    else
-#        error "Unable to locate Homebrew ncurses headers. Install ncurses with wide-character support (brew install ncurses)."
+#        error "Unable to locate macOS SDK curses headers. Ensure the Command Line Tools are installed (xcode-select --install) or that the SDK includes curses."
 #    endif
 #else
 #    if __has_include(<ncursesw/curses.h>)


### PR DESCRIPTION
## Summary
- update the Apple shim to prefer the macOS SDK's curses.h instead of Homebrew-specific headers
- refresh the guidance for missing headers to point developers toward enabling Command Line Tools or ensuring the SDK ships curses

## Testing
- swift build

------
https://chatgpt.com/codex/tasks/task_b_68cedd5aa0088333bf3133b3d2193459