### PR TITLE
Cap stack allocation at measured sizes

### DIFF
--- a/Sources/SwiftCursesKit/Scene/SceneRenderer.swift
+++ b/Sources/SwiftCursesKit/Scene/SceneRenderer.swift
@@ -273,24 +273,18 @@ private extension SceneRenderer {
 
     func distribute(available: Int, sizes: [Int]) -> [Int] {
         guard !sizes.isEmpty else { return [] }
-        if available <= 0 {
+        guard available > 0 else {
             return Array(repeating: 0, count: sizes.count)
         }
+
         var assigned = Array(repeating: 0, count: sizes.count)
         var remaining = available
         for index in sizes.indices {
-            let slotsLeft = sizes.count - index
-            if slotsLeft <= 0 { break }
-            let minimum = max(0, remaining - max(0, slotsLeft - 1) * 1)
-            var proposed = remaining / slotsLeft
-            if proposed == 0 && remaining > 0 {
-                proposed = 1
-            }
-            proposed = min(proposed, sizes[index])
-            proposed = max(minimum, proposed)
-            proposed = min(proposed, remaining)
-            assigned[index] = proposed
-            remaining -= proposed
+            guard remaining > 0 else { break }
+            let requested = max(0, sizes[index])
+            let allocation = min(requested, remaining)
+            assigned[index] = allocation
+            remaining -= allocation
         }
         return assigned
     }

--- a/Tests/SwiftCursesKitTests/SceneLayoutTests.swift
+++ b/Tests/SwiftCursesKitTests/SceneLayoutTests.swift
@@ -25,7 +25,7 @@ final class SceneLayoutTests: XCTestCase {
 
         XCTAssertEqual(environmentDouble.drawCalls.count, 2)
         XCTAssertEqual(environmentDouble.drawCalls[0].origin, LayoutPoint(x: 0, y: 0))
-        XCTAssertEqual(environmentDouble.drawCalls[1].origin, LayoutPoint(x: 0, y: 5))
+        XCTAssertEqual(environmentDouble.drawCalls[1].origin, LayoutPoint(x: 0, y: 3))
         let verticalLabels = environmentDouble.drawCalls.map { command in
             command.text.trimmingCharacters(in: .whitespaces)
         }
@@ -33,6 +33,67 @@ final class SceneLayoutTests: XCTestCase {
         XCTAssertEqual(environmentDouble.clearedCount, 1)
         XCTAssertEqual(environmentDouble.stagedCount, 1)
         XCTAssertEqual(environmentDouble.commitCount, 1)
+    }
+
+    func testHStackDoesNotStretchChildrenBeyondMeasurements() throws {
+        let environmentDouble = TestCNCursesEnvironment()
+        environmentDouble.windowSize = (rows: 4, columns: 20)
+        CNCursesBridge.environment = environmentDouble.makeEnvironment()
+
+        let screen = environmentDouble.makeScreen()
+        let firstWidth = 4
+        let secondWidth = 3
+        let widgetA = RecordingWidget(
+            label: String(repeating: "A", count: firstWidth),
+            measured: LayoutSize(width: firstWidth, height: 1)
+        )
+        let widgetB = RecordingWidget(
+            label: String(repeating: "B", count: secondWidth),
+            measured: LayoutSize(width: secondWidth, height: 1)
+        )
+        let scene = HStack(spacing: 1) {
+            WidgetView(widgetA)
+            WidgetView(widgetB)
+        }
+
+        let renderer = SceneRenderer()
+        try renderer.render(scene: scene, on: screen)
+
+        XCTAssertEqual(environmentDouble.drawCalls.count, 2)
+        XCTAssertEqual(environmentDouble.drawCalls[0].text.count, firstWidth)
+        XCTAssertEqual(environmentDouble.drawCalls[1].text.count, secondWidth)
+        XCTAssertEqual(environmentDouble.drawCalls[1].origin.x, firstWidth + 1)
+    }
+
+    func testVStackLeavesUnusedRowsInsteadOfInflatingChildren() throws {
+        let environmentDouble = TestCNCursesEnvironment()
+        environmentDouble.windowSize = (rows: 12, columns: 10)
+        CNCursesBridge.environment = environmentDouble.makeEnvironment()
+
+        let screen = environmentDouble.makeScreen()
+        let firstHeight = 2
+        let secondHeight = 3
+        let widgetA = RecordingWidget(
+            label: "Top",
+            measured: LayoutSize(width: 4, height: firstHeight)
+        )
+        let widgetB = RecordingWidget(
+            label: "Bottom",
+            measured: LayoutSize(width: 5, height: secondHeight)
+        )
+        let scene = VStack(spacing: 0) {
+            WidgetView(widgetA)
+            WidgetView(widgetB)
+        }
+
+        let renderer = SceneRenderer()
+        try renderer.render(scene: scene, on: screen)
+
+        XCTAssertEqual(environmentDouble.drawCalls.count, 2)
+        XCTAssertEqual(environmentDouble.drawCalls[0].text.count, widgetA.measured.width)
+        XCTAssertEqual(environmentDouble.drawCalls[1].text.count, widgetB.measured.width)
+        XCTAssertEqual(environmentDouble.drawCalls[0].origin.y, 0)
+        XCTAssertEqual(environmentDouble.drawCalls[1].origin.y, firstHeight)
     }
 
     func testSplitDistributesSpaceAccordingToFraction() throws {


### PR DESCRIPTION
## Summary
- update stack space distribution to avoid over-allocating beyond measured sizes
- add horizontal and vertical regression tests ensuring spare space is left unused

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_b_68cf743ae59883339b84455ce4dd5e70