### PR TITLE
Fix color pair allocation caching on failure

### DIFF
--- a/Tests/SwiftCursesKitTests/ColorPairRegistryTests.swift
+++ b/Tests/SwiftCursesKitTests/ColorPairRegistryTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+@testable import SwiftCursesKit
+
+final class ColorPairRegistryTests: XCTestCase {
+    private enum TestError: Error { case failure }
+
+    func testInitializationFailureDoesNotCachePair() throws {
+        let testEnvironment = TestCNCursesEnvironment()
+        testEnvironment.colorHasSupport = true
+        testEnvironment.colorCountValue = 8
+        testEnvironment.colorPairCountValue = 8
+        testEnvironment.colorEnableDefaultColors = true
+
+        let originalEnvironment = CNCursesBridge.environment
+        defer { CNCursesBridge.environment = originalEnvironment }
+        CNCursesBridge.environment = testEnvironment.makeEnvironment()
+
+        let registry = ColorPairRegistry()
+        registry.updateCapabilities(
+            TerminalCapabilities(
+                isHeadless: false,
+                supportsColor: true,
+                colorCount: 8,
+                colorPairCount: 8,
+                supportsDefaultColors: true,
+                supportsDynamicColorChanges: false,
+                supportsMouse: false
+            )
+        )
+
+        let configuration = ColorPairConfiguration(
+            foreground: .red,
+            background: .blue
+        )
+
+        testEnvironment.colorInitializeError = TestError.failure
+
+        XCTAssertThrowsError(try registry.pair(for: configuration)) { error in
+            XCTAssertEqual(error as? ColorPaletteError, .ncursesCallFailed(code: -1))
+        }
+        XCTAssertTrue(testEnvironment.initializedPairs.isEmpty)
+
+        testEnvironment.colorInitializeError = nil
+
+        let allocatedPair = try registry.pair(for: configuration)
+        XCTAssertEqual(allocatedPair.rawValue, 1)
+        XCTAssertEqual(testEnvironment.initializedPairs.count, 1)
+        XCTAssertEqual(testEnvironment.initializedPairs.first?.0, allocatedPair.rawValue)
+
+        let cachedPair = try registry.pair(for: configuration)
+        XCTAssertEqual(cachedPair, allocatedPair)
+        XCTAssertEqual(testEnvironment.initializedPairs.count, 1)
+    }
+}

--- a/Tests/SwiftCursesKitTests/TestSupport/TestCNCursesEnvironment.swift
+++ b/Tests/SwiftCursesKitTests/TestSupport/TestCNCursesEnvironment.swift
@@ -31,6 +31,7 @@ final class TestCNCursesEnvironment: @unchecked Sendable {
     var colorPairCountValue = 0
     var colorEnableDefaultColors = false
     var colorCanChange = false
+    var colorInitializeError: Error?
     private(set) var initializedPairs: [(Int16, Int16, Int16)] = []
 
     var mouseHasSupport = false
@@ -144,6 +145,9 @@ final class TestCNCursesEnvironment: @unchecked Sendable {
                     self?.colorCanChange ?? false
                 },
                 initializePair: { [weak self] identifier, foreground, background in
+                    if let error = self?.colorInitializeError {
+                        throw error
+                    }
                     self?.initializedPairs.append((identifier, foreground, background))
                 },
                 blackIdentifier: { 0 },


### PR DESCRIPTION
## Summary
- defer caching newly allocated color pairs until ncurses initialization succeeds
- allow the test CNCurses environment to throw during pair initialization to simulate failures
- add a regression test to ensure failed initialization retries instead of returning a cached pair

## Testing
- swift build
- swift test

------
https://chatgpt.com/codex/tasks/task_b_68cf75221d1c8333a3520a3738ac74b1